### PR TITLE
Adding release date of EUBUCCU and OSM timestamp to plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - building-comparison: AOI is now clipped to the coverage area ([#739])
 - mapping-saturation: add hover info to estimated total data line ([#723])
 - building-comparison: now has link to reference datasets ([#741])
+- building-comparison: added publication date of reference dataset and OSM Timestamp([#750])
 
 ### Other Changes
 

--- a/ohsome_quality_api/indicators/building_comparison/sources.yaml
+++ b/ohsome_quality_api/indicators/building_comparison/sources.yaml
@@ -1,0 +1,5 @@
+---
+# set source link and publishing date of compare datasets
+EUBUCCO:
+  link: https://docs.eubucco.com
+  date: 1900

--- a/ohsome_quality_api/indicators/building_comparison/sources.yaml
+++ b/ohsome_quality_api/indicators/building_comparison/sources.yaml
@@ -2,4 +2,4 @@
 # set source link and publishing date of compare datasets
 EUBUCCO:
   link: https://docs.eubucco.com
-  date: 1900
+  date: Nov 3, 2022

--- a/tests/integrationtests/indicators/test_building_comparison.py
+++ b/tests/integrationtests/indicators/test_building_comparison.py
@@ -209,4 +209,4 @@ class TestFigure:
 
 def test_get_sources():
     source = get_sources(["EUBUCCO"])
-    assert source == "<a href='https://docs.eubucco.com/'>EUBUCCO</a>"
+    assert source == "<a href='https://docs.eubucco.com'>EUBUCCO</a>"


### PR DESCRIPTION
### Description
Adding the release date of EUBUCCU and OSM timestamp to plot. Furthermore, laying groundwork to use same infrastructure for future further datasets

### Corresponding issue
Closes #750

### New or changed dependencies
-

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-api/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-api/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-api/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-api/blob/main/CHANGELOG.md)
