### PR TITLE
fix(building-comparison): label description

### DIFF
--- a/ohsome_quality_api/indicators/building_comparison/metadata.yaml
+++ b/ohsome_quality_api/indicators/building_comparison/metadata.yaml
@@ -14,7 +14,7 @@ building-comparison:
     yellow: >-
       OSM has a bit less building area than the reference data.
     green: >-
-      OSM has equal or more building area than the reference data.
+      OSM has almost the same, the same or even more building area than the reference data.
     undefined: >-
       Comparison could not be made.
   result_description: >-


### PR DESCRIPTION
Avoid folling case:
> The building area of OSM is 96.66% of that of the reference data. OSM has equal or more building area than the reference data.