### PR TITLE
feat(building-comparison): bug fixing after multiple reference datasets change

### DIFF
--- a/ohsome_quality_api/indicators/building_comparison/datasets.yaml
+++ b/ohsome_quality_api/indicators/building_comparison/datasets.yaml
@@ -9,6 +9,7 @@ EUBUCCO:
   coverage:
     simple: eubucco_v0_1_coverage_simple
     inversed: eubucco_v0_1_coverage_inversed
+  table_name: eubucco
 
 Microsoft Buildings:
     name: Microsoft Building Footprints
@@ -21,3 +22,4 @@ Microsoft Buildings:
     coverage:
       simple: microsoft_buildings_coverage_simple
       inversed: microsoft_buildings_coverage_inversed
+    table_name: microsoft_buildings_2024_01_03

--- a/ohsome_quality_api/indicators/building_comparison/indicator.py
+++ b/ohsome_quality_api/indicators/building_comparison/indicator.py
@@ -60,9 +60,7 @@ class BuildingComparison(BaseIndicator):
                 table = val["coverage"]["inversed"]
             else:
                 table = val["coverage"]["simple"]
-            feature_str = await db_client.get_reference_coverage(table)
-            geojson_dict = geojson.loads(feature_str)
-            feature = Feature(geometry=geojson_dict, properties={})
+            feature = await db_client.get_reference_coverage(table)
             feature.properties.update({"refernce_dataset": val["name"]})
             features.append(feature)
             return features

--- a/ohsome_quality_api/indicators/building_comparison/indicator.py
+++ b/ohsome_quality_api/indicators/building_comparison/indicator.py
@@ -208,23 +208,20 @@ class BuildingComparison(BaseIndicator):
             ]
         )
 
-        # Put every reference dataset to legend by adding transparent shapes
-        # do only if more than 1 reference data exists, so no edge_case
-        if not any(edge_cases):
-            for i, dataset in enumerate(list(self.data_ref.values())[1:]):
-                fig.add_shape(
-                    name=dataset["name"] + f" ({ref_area[i+1]} km²)",
-                    legendgroup="Reference",
-                    showlegend=True,
-                    type="rect",
-                    layer="below",
-                    line=dict(width=0),
-                    fillcolor=Color[dataset["color"]].value,
-                    x0=0,
-                    y0=0,
-                    x1=0,
-                    y1=0,
-                )
+        for name, area, color in zip(ref_x[1:], ref_area[1:], ref_color[1:]):
+            fig.add_shape(
+                name=name + f" ({area} km²)",
+                legendgroup="Reference",
+                showlegend=True,
+                type="rect",
+                layer="below",
+                line=dict(width=0),
+                fillcolor=color,
+                x0=0,
+                y0=0,
+                x1=0,
+                y1=0,
+            )
 
         layout = {
             "title_text": "Building Comparison",

--- a/ohsome_quality_api/indicators/building_comparison/indicator.py
+++ b/ohsome_quality_api/indicators/building_comparison/indicator.py
@@ -63,7 +63,7 @@ class BuildingComparison(BaseIndicator):
             feature = await db_client.get_reference_coverage(table)
             feature.properties.update({"refernce_dataset": val["name"]})
             features.append(feature)
-            return features
+        return features
 
     @classmethod
     def attribution(cls) -> str:

--- a/ohsome_quality_api/indicators/building_comparison/indicator.py
+++ b/ohsome_quality_api/indicators/building_comparison/indicator.py
@@ -119,15 +119,20 @@ class BuildingComparison(BaseIndicator):
             # TODO: add warning for user, that no buildings are present?
             try:
                 self.ratio[key] = self.area_osm[key] / self.area_ref[key]
-            except ZeroDivisionError:
-                self.ratio[key] = 0.0
 
-            template = Template(self.metadata.result_description)
-            self.result.description += template.substitute(
-                ratio=round(self.ratio[key] * 100, 2),
-                coverage=round(self.area_cov[key] * 100, 2),
-                dataset=self.data_ref[key]["name"],
-            )
+                template = Template(self.metadata.result_description)
+                self.result.description += template.substitute(
+                    ratio=round(self.ratio[key] * 100, 2),
+                    coverage=round(self.area_cov[key] * 100, 2),
+                    dataset=self.data_ref[key]["name"],
+                )
+            except ZeroDivisionError:
+                self.ratio[key] = None
+                self.result.description += (
+                    f"Warning: Reference dataset {self.data_ref[key]['name']} covers "
+                    f"AoI with {round(self.area_cov[key] * 100, 2)}%, but has no "
+                    "building area. No quality estimation with reference is possible. "
+                )
 
         ratios = [v for v in self.ratio.values() if v is not None]
         ratios = [v for v in ratios if v <= self.above_one_th]

--- a/ohsome_quality_api/indicators/building_comparison/indicator.py
+++ b/ohsome_quality_api/indicators/building_comparison/indicator.py
@@ -87,7 +87,9 @@ class BuildingComparison(BaseIndicator):
             )
 
             # get reference building area
-            result = await get_reference_building_area(geojson.dumps(feature), key)
+            result = await get_reference_building_area(
+                geojson.dumps(feature), val["table_name"]
+            )
             self.area_ref[key] = result / (1000 * 1000)
 
             # get osm building area

--- a/ohsome_quality_api/indicators/building_comparison/indicator.py
+++ b/ohsome_quality_api/indicators/building_comparison/indicator.py
@@ -209,20 +209,22 @@ class BuildingComparison(BaseIndicator):
         )
 
         # Put every reference dataset to legend by adding transparent shapes
-        for i, dataset in enumerate(list(self.data_ref.values())[1:]):
-            fig.add_shape(
-                name=dataset["name"] + f" ({ref_area[i+1]} km²)",
-                legendgroup="Reference",
-                showlegend=True,
-                type="rect",
-                layer="below",
-                line=dict(width=0),
-                fillcolor=Color[dataset["color"]].value,
-                x0=0,
-                y0=0,
-                x1=0,
-                y1=0,
-            )
+        # do only if more than 1 reference data exists, so no edge_case
+        if not any(edge_cases):
+            for i, dataset in enumerate(list(self.data_ref.values())[1:]):
+                fig.add_shape(
+                    name=dataset["name"] + f" ({ref_area[i+1]} km²)",
+                    legendgroup="Reference",
+                    showlegend=True,
+                    type="rect",
+                    layer="below",
+                    line=dict(width=0),
+                    fillcolor=Color[dataset["color"]].value,
+                    x0=0,
+                    y0=0,
+                    x1=0,
+                    y1=0,
+                )
 
         layout = {
             "title_text": "Building Comparison",

--- a/tests/integrationtests/indicators/test_building_comparison.py
+++ b/tests/integrationtests/indicators/test_building_comparison.py
@@ -208,7 +208,7 @@ class TestCalculate:
         indicator = BuildingComparison(topic_building_area, feature_germany_heidelberg)
         asyncio.run(indicator.preprocess())
         indicator.calculate()
-        assert indicator.result.value == 0.0
+        assert indicator.result.value is None
 
     @oqapi_vcr.use_cassette
     @pytest.mark.usefixtures(

--- a/tests/unittests/test_indicators_definitions.py
+++ b/tests/unittests/test_indicators_definitions.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock
 
 import geojson
 import pytest
-from geojson import Polygon
+from geojson import Feature, Polygon
 
 from ohsome_quality_api.indicators import definitions, models
 
@@ -11,19 +11,17 @@ from ohsome_quality_api.indicators import definitions, models
 @pytest.fixture(scope="class")
 def mock_get_reference_coverage(class_mocker):
     async_mock = AsyncMock(
-        return_value=str(
-            geojson.dumps(
-                Polygon(
-                    coordinates=[
-                        [
-                            (-180, 90),
-                            (-180, -90),
-                            (180, -90),
-                            (180, 90),
-                            (-180, 90),
-                        ]
+        return_value=Feature(
+            geometry=Polygon(
+                coordinates=[
+                    [
+                        (-180, 90),
+                        (-180, -90),
+                        (180, -90),
+                        (180, 90),
+                        (-180, 90),
                     ]
-                )
+                ]
             )
         )
     )


### PR DESCRIPTION
### Description
fixes the bug described in issue #771 by using the feature directly instead of trying to create one from a string

### Corresponding issue
Closes #771 
Closes #773 

### New or changed dependencies
- None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-api/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-api/blob/main/CONTRIBUTING.md#pre-commit) before committing
- ~[ ] I have commented my code~
- [x] check coverage display in dashbaord
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-api/blob/main/docs/development_setup.md#tests)
- ~[ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-api/blob/main/CHANGELOG.md)~