### PR TITLE
attribute-completeness: do not create figure if no objects are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - New Topics and Project for UNICEF education access project have been added ([#832])
 
+### Bug Fixes
+
+- fix: global coverage is now returned correctly ([#821])
+
+
+[#821]: https://github.com/GIScience/ohsome-quality-api/issues/821
+
 
 ## Release  1.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - fix: invalid example GeoJSON in swagger ([#831])
 - fix: global coverage is now returned correctly ([#821])
-- attribute-completeness: no figure creation if quality could not be calculated ([#830])
+- attribute-completeness: no figure creation if quality could not be calculated ([#829])
 
 
 [#821]: https://github.com/GIScience/ohsome-quality-api/issues/821

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Current Main 
 
+### New Features
+
+- New Topics and Project for UNICEF education access project have been added ([#832])
+
+
 ## Release  1.5.0
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@
 
 - fix: invalid example GeoJSON in swagger ([#831])
 - fix: global coverage is now returned correctly ([#821])
+- attribute-completeness: no figure creation if quality could not be calculated ([#830])
 
 
 [#821]: https://github.com/GIScience/ohsome-quality-api/issues/821
+[#829]: https://github.com/GIScience/ohsome-quality-api/issues/829
 [#831]: https://github.com/GIScience/ohsome-quality-api/issues/831
 [#832]: https://github.com/GIScience/ohsome-quality-api/issues/832
 
@@ -27,7 +29,6 @@
 ### New Features
 
 - attribute-completeness: new topic-specific attributes have been added ([#826])
-
 
 ### Other Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@
 
 ### Bug Fixes
 
+- fix: invalid example GeoJSON in swagger ([#831])
 - fix: global coverage is now returned correctly ([#821])
 
 
 [#821]: https://github.com/GIScience/ohsome-quality-api/issues/821
+[#831]: https://github.com/GIScience/ohsome-quality-api/issues/831
+[#832]: https://github.com/GIScience/ohsome-quality-api/issues/832
 
 
 ## Release  1.5.0

--- a/ohsome_quality_api/api/request_models.py
+++ b/ohsome_quality_api/api/request_models.py
@@ -41,7 +41,8 @@ class BaseBpolys(BaseConfig):
                             ]
                         ],
                     },
-                },
+                    "properties": {},
+                }
             ],
         }
     )

--- a/ohsome_quality_api/indicators/attribute_completeness/indicator.py
+++ b/ohsome_quality_api/indicators/attribute_completeness/indicator.py
@@ -1,3 +1,4 @@
+import logging
 from string import Template
 from typing import List
 
@@ -66,15 +67,13 @@ class AttributeCompleteness(BaseIndicator):
         if self.result.value == "NaN":
             self.result.value = None
         if self.result.value is None:
+            self.result.description += " No features in this region"
             return
         description = Template(self.templates.result_description).substitute(
             result=round(self.result.value, 2),
             all=round(self.absolute_value_1, 1),
             matched=round(self.absolute_value_2, 1),
         )
-        if self.absolute_value_1 == 0:
-            self.result.description = description + "No features in this region"
-            return
 
         if self.result.value >= self.threshold_yellow:
             self.result.class_ = 5
@@ -98,6 +97,9 @@ class AttributeCompleteness(BaseIndicator):
         The gauge chart shows the percentage of features having the requested
         attribute(s).
         """
+        if self.result.label == "undefined":
+            logging.info("Result is undefined. Skipping figure creation.")
+            return
 
         fig = go.Figure(
             go.Indicator(

--- a/ohsome_quality_api/indicators/base.py
+++ b/ohsome_quality_api/indicators/base.py
@@ -132,7 +132,7 @@ class BaseIndicator(metaclass=ABCMeta):
                 )
             ]
         else:
-            return [Feature(Polygon(coordinates=[]))]
+            return [Feature(geometry=Polygon(coordinates=[]))]
 
     @abstractmethod
     async def preprocess(self) -> None:

--- a/ohsome_quality_api/indicators/indicators.yaml
+++ b/ohsome_quality_api/indicators/indicators.yaml
@@ -20,6 +20,7 @@ currentness:
   projects:
     - core
     - bkg
+    - unicef
   quality_dimension: currentness
   description: >-
     Estimate currentness of features by classifying contributions based on
@@ -30,6 +31,7 @@ road-comparison:
   projects:
     - bkg
     - core
+    - unicef
   quality_dimension: completeness
   description: >-
     Compare the road length of OSM roads with the road length of
@@ -45,6 +47,7 @@ mapping-saturation:
     - mapaction
     - sketchmap
     - bkg
+    - unicef
   quality_dimension: completeness
   description: >-
     Calculate if mapping has saturated.

--- a/ohsome_quality_api/projects/projects.yaml
+++ b/ohsome_quality_api/projects/projects.yaml
@@ -16,6 +16,11 @@ sketchmap:
   description: >-
     something that is still a TODO
 
+unicef:
+  name: TODO
+  description: >-
+    something that is still a TODO
+
 misc:
   name: TODO
   description: >-

--- a/ohsome_quality_api/topics/presets.yaml
+++ b/ohsome_quality_api/topics/presets.yaml
@@ -147,6 +147,7 @@ schools:
   projects:
     - core
     - bkg
+    - unicef
 
 kindergarten:
   name: Kindergarten
@@ -365,6 +366,7 @@ hospitals:
   projects:
     - core
     - bkg
+    - unicef
 
 ### UNICEF PROJECT ###
 

--- a/ohsome_quality_api/topics/presets.yaml
+++ b/ohsome_quality_api/topics/presets.yaml
@@ -366,6 +366,42 @@ hospitals:
     - core
     - bkg
 
+### UNICEF PROJECT ###
+
+roads-unicef:
+  name: UNICEF Roads
+  description: >-
+    The road network usable for routing as defined for the UNICEF Project.
+  endpoint: elements
+  aggregation_type: length
+  filter: >-
+    highway in (motorway, motorway_link, motorroad, trunk, trunk_link, primary, primary_link, secondary, secondary_link,
+    tertiary, tertiary_link, unclassified, residential, living_street, service, road, track)
+  ratio_filter: >-
+    (highway in (motorway, motorway_link, motorroad, trunk, trunk_link, primary, primary_link, secondary, 
+    secondary_link, tertiary, tertiary_link, unclassified, residential, living_street, service, road, track)) and name=*
+  source: https://heigit.atlassian.net/wiki/spaces/GIS/pages/756645935/2024-10-01+Unicef+education+access
+  indicators:
+    - mapping-saturation
+    - road-comparison
+    - attribute-completeness
+    - currentness  # currentness always requests /contributions/latest/count [count!]
+  projects:
+    - unicef
+
+healthcare-primary:
+  name: Primary Healthcare facilities for UNICEF Project
+  description: Count of hospitals.
+  endpoint: elements
+  aggregation_type: count
+  filter: amenity in (clinic, doctors, health_post) or healthcare in (clinic, doctors, doctor, midwife, nurse, center)
+  source: https://heigit.atlassian.net/wiki/spaces/GIS/pages/756645935/2024-10-01+Unicef+education+access
+  indicators:
+    - mapping-saturation
+    - currentness
+  projects:
+    - unicef
+
 ### SKETCHMAP PROJECT ###
 
 amenities:

--- a/regression-tests/roads_polygon_attributecompleteness.hurl
+++ b/regression-tests/roads_polygon_attributecompleteness.hurl
@@ -13,7 +13,7 @@ bytes count > 1900
 
 jsonpath "$.result[0].metadata.name" == "Attribute Completeness"
 jsonpath "$.result[0].topic.name" == "Roads"
-jsonpath "$.result[0].result.description" contains "The ratio of the features (all: 1034299.9) compared to features with expected tags (matched: 276785.2) is 0.27."
+jsonpath "$.result[0].result.description" contains "The ratio of the features (all: 1034408.4) compared to features with expected tags (matched: 278118.2) is 0.27. Around 25-75% of the features match the expected tags."
 jsonpath "$.result[0].result.figure.data[0].gauge.steps[0].color" == "tomato"
 jsonpath "$.result[0].result.label" == "yellow"
 

--- a/regression-tests/roads_polygon_mappingsaturation.hurl
+++ b/regression-tests/roads_polygon_mappingsaturation.hurl
@@ -12,7 +12,7 @@ status == 200
 bytes count > 24000
 
 jsonpath "$.result[0].topic.name" == "Roads"
-jsonpath "$.result[0].result.description" contains "The saturation of the last 3 years is 98.3%.High saturation has been reached (97% < Saturation ≤ 100%)."
+jsonpath "$.result[0].result.description" contains "The saturation of the last 3 years is 98.46%.High saturation has been reached (97% < Saturation ≤ 100%)."
 jsonpath "$.result[0].result.figure.data[0].line.color" == "#2185D0"
 jsonpath "$.result[0].result.label" == "green"
 

--- a/tests/integrationtests/api/conftest.py
+++ b/tests/integrationtests/api/conftest.py
@@ -61,6 +61,7 @@ def metadata_indicator_mapping_saturation():
                 "mapaction",
                 "sketchmap",
                 "bkg",
+                "unicef",
             ],
             "qualityDimension": "completeness",
         }

--- a/tests/integrationtests/test_base_indicator.py
+++ b/tests/integrationtests/test_base_indicator.py
@@ -65,15 +65,18 @@ class TestBaseIndicator:
         for feature in coverage:
             assert isinstance(feature, Feature)
             assert feature.is_valid
+            assert feature["geometry"] is not None
         coverage_default = asyncio.run(Minimal.coverage())
         for feature in coverage_default:
             assert isinstance(feature, Feature)
             assert feature.is_valid
+            assert feature["geometry"] is not None
         assert coverage_default == coverage
         coverage_inversed = asyncio.run(Minimal.coverage(inverse=True))
         for feature in coverage_inversed:
             assert isinstance(feature, Feature)
             assert feature.is_valid
+            assert feature["geometry"] is not None
         assert coverage != coverage_inversed
         assert coverage_default != coverage_inversed
 


### PR DESCRIPTION
Skip figure creation if calculation could not be made and add to description that no elements are present.

### Corresponding issue
Closes #829


### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-api/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-api/blob/main/CONTRIBUTING.md#pre-commit) before committing
~- [ ] I have commented my code~
~- [ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-api/blob/main/docs/development_setup.md#tests)~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-api/blob/main/CHANGELOG.md)
