### PR TITLE
fix: invalid example GeoJSON in swagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - New Topics and Project for UNICEF education access project have been added ([#832])
 
+### Bug Fixes
+
+- fix: invalid example GeoJSON in swagger ([#831])
+
+[#831]: https://github.com/GIScience/ohsome-quality-api/issues/831
+
 
 ## Release  1.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - fix: invalid example GeoJSON in swagger ([#831])
 
+
 [#831]: https://github.com/GIScience/ohsome-quality-api/issues/831
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Current Main 
 
+### New Features
+
+- New Topics and Project for UNICEF education access project have been added ([#832])
+
+
 ## Release  1.5.0
 
 ### Breaking Changes

--- a/ohsome_quality_api/api/request_models.py
+++ b/ohsome_quality_api/api/request_models.py
@@ -41,7 +41,8 @@ class BaseBpolys(BaseConfig):
                             ]
                         ],
                     },
-                },
+                    "properties": {},
+                }
             ],
         }
     )

--- a/regression-tests/roads_polygon_attributecompleteness.hurl
+++ b/regression-tests/roads_polygon_attributecompleteness.hurl
@@ -13,7 +13,7 @@ bytes count > 1900
 
 jsonpath "$.result[0].metadata.name" == "Attribute Completeness"
 jsonpath "$.result[0].topic.name" == "Roads"
-jsonpath "$.result[0].result.description" contains "The ratio of the features (all: 1034299.9) compared to features with expected tags (matched: 276785.2) is 0.27."
+jsonpath "$.result[0].result.description" contains "The ratio of the features (all: 1034408.4) compared to features with expected tags (matched: 278118.2) is 0.27. Around 25-75% of the features match the expected tags."
 jsonpath "$.result[0].result.figure.data[0].gauge.steps[0].color" == "tomato"
 jsonpath "$.result[0].result.label" == "yellow"
 

--- a/regression-tests/roads_polygon_mappingsaturation.hurl
+++ b/regression-tests/roads_polygon_mappingsaturation.hurl
@@ -12,7 +12,7 @@ status == 200
 bytes count > 24000
 
 jsonpath "$.result[0].topic.name" == "Roads"
-jsonpath "$.result[0].result.description" contains "The saturation of the last 3 years is 98.3%.High saturation has been reached (97% < Saturation ≤ 100%)."
+jsonpath "$.result[0].result.description" contains "The saturation of the last 3 years is 98.46%.High saturation has been reached (97% < Saturation ≤ 100%)."
 jsonpath "$.result[0].result.figure.data[0].line.color" == "#2185D0"
 jsonpath "$.result[0].result.label" == "green"
 

--- a/tests/integrationtests/api/conftest.py
+++ b/tests/integrationtests/api/conftest.py
@@ -61,6 +61,7 @@ def metadata_indicator_mapping_saturation():
                 "mapaction",
                 "sketchmap",
                 "bkg",
+                "unicef",
             ],
             "qualityDimension": "completeness",
         }


### PR DESCRIPTION
Add missing properties dict to example GeoJSON.

### Corresponding issue
Closes #831

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-api/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-api/blob/main/CONTRIBUTING.md#pre-commit) before committing
~- [ ] I have commented my code~
~- [ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-api/blob/main/docs/development_setup.md#tests)~
- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-api/blob/main/CHANGELOG.md)
