### PR TITLE
fix: global coverage geojson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - New Topics and Project for UNICEF education access project have been added ([#832])
 
+### Bug Fixes
+
+- fix: global coverage is now returned correctly ([#821])
+
+
+[#821]: https://github.com/GIScience/ohsome-quality-api/issues/821
+
 
 ## Release  1.5.0
 

--- a/ohsome_quality_api/indicators/base.py
+++ b/ohsome_quality_api/indicators/base.py
@@ -132,7 +132,7 @@ class BaseIndicator(metaclass=ABCMeta):
                 )
             ]
         else:
-            return [Feature(Polygon(coordinates=[]))]
+            return [Feature(geometry=Polygon(coordinates=[]))]
 
     @abstractmethod
     async def preprocess(self) -> None:

--- a/tests/integrationtests/test_base_indicator.py
+++ b/tests/integrationtests/test_base_indicator.py
@@ -65,15 +65,18 @@ class TestBaseIndicator:
         for feature in coverage:
             assert isinstance(feature, Feature)
             assert feature.is_valid
+            assert feature["geometry"] is not None
         coverage_default = asyncio.run(Minimal.coverage())
         for feature in coverage_default:
             assert isinstance(feature, Feature)
             assert feature.is_valid
+            assert feature["geometry"] is not None
         assert coverage_default == coverage
         coverage_inversed = asyncio.run(Minimal.coverage(inverse=True))
         for feature in coverage_inversed:
             assert isinstance(feature, Feature)
             assert feature.is_valid
+            assert feature["geometry"] is not None
         assert coverage != coverage_inversed
         assert coverage_default != coverage_inversed
 


### PR DESCRIPTION
### Description

Fix wrong creation of global coverage in the base indicator.

### Corresponding issue
Closes #821

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-api/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-api/blob/main/CONTRIBUTING.md#pre-commit) before committing
~- [ ] I have commented my code~
~- [ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-api/blob/main/docs/development_setup.md#tests)~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-api/blob/main/CHANGELOG.md)
