### PR TITLE
Address deprication warning

### DIFF
--- a/ohsome_quality_api/utils/helper.py
+++ b/ohsome_quality_api/utils/helper.py
@@ -3,10 +3,10 @@
 import importlib
 import logging
 import os
-import pkgutil
 import re
 from datetime import date, datetime
 from enum import Enum
+from importlib.util import find_spec
 from pathlib import Path
 
 import geojson
@@ -73,8 +73,8 @@ def snake_to_hyphen(snake: str) -> str:
 
 def get_module_dir(module_name: str) -> str:
     """Get directory of module name."""
-    module = pkgutil.get_loader(module_name)
-    return os.path.dirname(module.get_filename())
+    module = find_spec(module_name)
+    return os.path.dirname(module.loader.get_filename())
 
 
 def json_serialize(obj):

--- a/tests/unittests/test_helper.py
+++ b/tests/unittests/test_helper.py
@@ -15,6 +15,7 @@ from ohsome_quality_api.utils.helper import (
     camel_to_hyphen,
     flatten_sequence,
     get_class_from_key,
+    get_module_dir,
     get_project_root,
     hyphen_to_camel,
     hyphen_to_snake,
@@ -103,6 +104,12 @@ class TestHelper(unittest.TestCase):
 
     def test_hyphen_to_snake(self):
         assert hyphen_to_snake("hyphen-case") == "hyphen_case"
+
+    def test_get_module_dir(self):
+        assert (
+            get_module_dir("ohsome_quality_api.definitions")
+            == "/home/matthias/work/projects/oqapi/ohsome_quality_api"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unittests/test_helper.py
+++ b/tests/unittests/test_helper.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from ohsome_quality_api.indicators.base import BaseIndicator
 from ohsome_quality_api.indicators.definitions import get_indicator_metadata
 from ohsome_quality_api.indicators.mapping_saturation import models
 from ohsome_quality_api.indicators.minimal.indicator import Minimal
@@ -29,8 +30,9 @@ def test_name_to_class():
 
     indicators = get_indicator_metadata()
     for indicator_name in indicators.keys():
-        assert (
-            get_class_from_key(class_type="indicator", key=indicator_name) is not None
+        assert issubclass(
+            get_class_from_key(class_type="indicator", key=indicator_name),
+            BaseIndicator,
         )
 
 
@@ -107,7 +109,4 @@ def test_hyphen_to_snake():
 
 
 def test_get_module_dir():
-    assert (
-        get_module_dir("ohsome_quality_api.definitions")
-        == "/home/matthias/work/projects/oqapi/ohsome_quality_api"
-    )
+    assert get_module_dir("tests.unittests") == str(Path(__file__).parent)

--- a/tests/unittests/test_helper.py
+++ b/tests/unittests/test_helper.py
@@ -1,16 +1,12 @@
 import datetime
-import os
-import unittest
 from pathlib import Path
 
-import geojson
 import numpy as np
+import pytest
 
 from ohsome_quality_api.indicators.definitions import get_indicator_metadata
 from ohsome_quality_api.indicators.mapping_saturation import models
-from ohsome_quality_api.indicators.minimal.indicator import (
-    Minimal as MinimalIndicator,
-)
+from ohsome_quality_api.indicators.minimal.indicator import Minimal
 from ohsome_quality_api.utils.helper import (
     camel_to_hyphen,
     flatten_sequence,
@@ -28,89 +24,90 @@ from ohsome_quality_api.utils.helper import (
 from .mapping_saturation import fixtures
 
 
-def get_fixture(name):
-    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures", name)
-    with open(path, "r") as file:
-        return geojson.load(file)
+def test_name_to_class():
+    assert get_class_from_key(class_type="indicator", key="minimal") == Minimal
 
-
-class TestHelper(unittest.TestCase):
-    def test_name_to_class(self):
-        self.assertIs(
-            get_class_from_key(class_type="indicator", key="minimal"),
-            MinimalIndicator,
-        )
-
-        self.indicators = get_indicator_metadata()
-        for indicator_name in self.indicators.keys():
-            self.assertIsNotNone(
-                get_class_from_key(class_type="indicator", key=indicator_name)
-            )
-
-    # TODO: add tests for other input than dict
-    def test_flatten_seq(self):
-        input_seq = {
-            "regions": {"default": "ogc_fid"},
-            "gadm": {
-                "default": "uid",  # ISO 3166-1 alpha-3 country code
-                "other": (("name_1", "name_2"), ("id_1", "id_2")),
-            },
-        }
-        output_seq = ["ogc_fid", "uid", "name_1", "name_2", "id_1", "id_2"]
-        self.assertListEqual(flatten_sequence(input_seq), output_seq)
-
-    def test_json_serialize_valid_input_datetime(self):
-        self.assertIsInstance(json_serialize(datetime.datetime.now()), str)
-
-    def test_json_serialize_valid_input_date(self):
-        self.assertIsInstance(json_serialize(datetime.date.today()), str)
-
-    def test_json_serialize_valid_input_np_float(self):
-        np_float = np.array([1.1])[0]
-        self.assertIsInstance(json_serialize(np_float), float)
-
-    def test_json_serialize_valid_input_np_int(self):
-        np_int = np.array([1])[0]
-        self.assertIsInstance(json_serialize(np_int), int)
-
-    def test_json_serialize_valid_input_fit(self):
-        ydata = fixtures.VALUES_1
-        xdata = np.array(range(len(ydata)))
-        self.assertIsInstance(json_serialize(models.SSlogis(xdata, ydata)), dict)
-
-    def test_json_serialize_invalid_input(self):
-        with self.assertRaises(TypeError):
-            json_serialize("foo")
-
-    def test_get_project_root(self):
-        expected = Path(__file__).resolve().parent.parent.parent.resolve()
-        result = get_project_root()
-        self.assertEqual(expected, result)
-
-    def test_camel_to_hyphen(self):
-        assert camel_to_hyphen("CamelCase") == "camel-case"
-
-    def test_snake_to_camel(self):
-        assert snake_to_camel("snake_case") == "SnakeCase"
-
-    def test_snake_to_lower_camel(self):
-        assert snake_to_lower_camel("snake_case") == "snakeCase"
-
-    def test_snake_to_hyphen(self):
-        assert snake_to_hyphen("snake_case") == "snake-case"
-
-    def test_hyphen_to_camel(self):
-        assert hyphen_to_camel("hyphen-case") == "HyphenCase"
-
-    def test_hyphen_to_snake(self):
-        assert hyphen_to_snake("hyphen-case") == "hyphen_case"
-
-    def test_get_module_dir(self):
+    indicators = get_indicator_metadata()
+    for indicator_name in indicators.keys():
         assert (
-            get_module_dir("ohsome_quality_api.definitions")
-            == "/home/matthias/work/projects/oqapi/ohsome_quality_api"
+            get_class_from_key(class_type="indicator", key=indicator_name) is not None
         )
 
 
-if __name__ == "__main__":
-    unittest.main()
+# TODO: add tests for other input than dict
+def test_flatten_seq():
+    input_seq = {
+        "regions": {"default": "ogc_fid"},
+        "gadm": {
+            "default": "uid",  # ISO 3166-1 alpha-3 country code
+            "other": (("name_1", "name_2"), ("id_1", "id_2")),
+        },
+    }
+    output_seq = ["ogc_fid", "uid", "name_1", "name_2", "id_1", "id_2"]
+    assert flatten_sequence(input_seq) == output_seq
+
+
+def test_json_serialize_valid_input_datetime():
+    assert isinstance(json_serialize(datetime.datetime.now()), str)
+
+
+def test_json_serialize_valid_input_date():
+    assert isinstance(json_serialize(datetime.date.today()), str)
+
+
+def test_json_serialize_valid_input_np_float():
+    np_float = np.array([1.1])[0]
+    assert isinstance(json_serialize(np_float), float)
+
+
+def test_json_serialize_valid_input_np_int():
+    np_int = np.array([1])[0]
+    assert isinstance(json_serialize(np_int), int)
+
+
+def test_json_serialize_valid_input_fit():
+    ydata = fixtures.VALUES_1
+    xdata = np.array(range(len(ydata)))
+    assert isinstance(json_serialize(models.SSlogis(xdata, ydata)), dict)
+
+
+def test_json_serialize_invalid_input():
+    with pytest.raises(TypeError):
+        json_serialize("foo")
+
+
+def test_get_project_root():
+    expected = Path(__file__).resolve().parent.parent.parent.resolve()
+    result = get_project_root()
+    assert expected == result
+
+
+def test_camel_to_hyphen():
+    assert camel_to_hyphen("CamelCase") == "camel-case"
+
+
+def test_snake_to_camel():
+    assert snake_to_camel("snake_case") == "SnakeCase"
+
+
+def test_snake_to_lower_camel():
+    assert snake_to_lower_camel("snake_case") == "snakeCase"
+
+
+def test_snake_to_hyphen():
+    assert snake_to_hyphen("snake_case") == "snake-case"
+
+
+def test_hyphen_to_camel():
+    assert hyphen_to_camel("hyphen-case") == "HyphenCase"
+
+
+def test_hyphen_to_snake():
+    assert hyphen_to_snake("hyphen-case") == "hyphen_case"
+
+
+def test_get_module_dir():
+    assert (
+        get_module_dir("ohsome_quality_api.definitions")
+        == "/home/matthias/work/projects/oqapi/ohsome_quality_api"
+    )


### PR DESCRIPTION
### Description

refactor: address deprecation warning

    pkgutil.get_loader(module_or_name) is deprecated since version 3.12,
    will be removed in version 3.14: Use importlib.util.find_spec() instead.

    importlib.util.find_spec() has been added in Python version 3.4.

test: rewrite unittests to by pytests and remove unused function

### Corresponding issue
Closes None

### New or changed dependencies
- None

### Checklist
- [x] I have ensured my branch is mergeable with `main` (e.g. through `git rebase main` if necessary)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-api/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-api/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-api/blob/main/docs/development_setup.md#tests)
- [ ] I have added new Hurl regression tests and checked all existing [tests](https://github.com/GIScience/ohsome-quality-api/blob/main/regression-tests/README.md)
- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-api/blob/main/CHANGELOG.md)

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
